### PR TITLE
Change nativescript-telerik-ui to nativescript-telerik-ui-pro

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -6,8 +6,8 @@ var list_view_1 = require("ui/list-view");
 var viewsModule = require("./shared/views");
 var navigationModule = require("navigation");
 var constants_1 = require("./shared/constants");
-var chartModule = require("nativescript-telerik-ui/chart");
-var listViewModule = require("nativescript-telerik-ui/listview");
+var chartModule = require("nativescript-telerik-ui-pro/chart");
+var listViewModule = require("nativescript-telerik-ui-pro/listview");
 var months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 specialPropertiesModule.registerSpecialProperty("link", function (instance, propertyValue) {
     if (instance instanceof list_view_1.ListView) {

--- a/app/app.ts
+++ b/app/app.ts
@@ -9,8 +9,8 @@ import navigationModule = require("navigation");
 import { reportStatus } from "./shared/constants";
 import colorModule = require("color");
 
-var chartModule = require("nativescript-telerik-ui/chart");
-var listViewModule = require("nativescript-telerik-ui/listview");
+var chartModule = require("nativescript-telerik-ui-pro/chart");
+var listViewModule = require("nativescript-telerik-ui-pro/listview");
 
 var months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 specialPropertiesModule.registerSpecialProperty("link", (instance, propertyValue) => {

--- a/app/views/reports/reports.xml
+++ b/app/views/reports/reports.xml
@@ -1,6 +1,6 @@
 <TabViewItem
-  xmlns:lv="nativescript-telerik-ui/listview"
-  xmlns:chart="nativescript-telerik-ui/chart"
+  xmlns:lv="nativescript-telerik-ui-pro/listview"
+  xmlns:chart="nativescript-telerik-ui-pro/chart"
   iconSource="{{ selectedTab === 0 ? 'res://ic_reports_1' : 'res://ic_reports' }}"
   ios:title="My reports" >
   <TabViewItem.view>

--- a/app/views/view-report/view-report.xml
+++ b/app/views/view-report/view-report.xml
@@ -1,6 +1,6 @@
 ﻿<Page xmlns="http://schemas.nativescript.org/tns.xsd"
       xmlns:g="components/grid-view/grid-view"
-      xmlns:chart="nativescript-telerik-ui/chart"
+      xmlns:chart="nativescript-telerik-ui-pro/chart"
       navigatingTo="onNavigatingTo" >
   <Page.actionBar >
     <ActionBar title="{{ report.Status | reportStatusConverter }}">

--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
-  "nativescript": {
-    "id": "org.nativescript.Xpensity",
-    "tns-android": {
-      "version": "1.7.1"
-    },
-    "tns-ios": {
-      "version": "1.7.0"
-    }
-  },
-  "devDependencies": {
-    "nativescript-dev-typescript": "^0.3.1",
-    "typescript": "^1.8.2"
-  },
-  "dependencies": {
-    "custom-control": "file:plugins\\custom-control",
-    "data-source": "file:plugins\\data-source",
-    "date-picker": "file:plugins\\date-picker",
-    "drop-down-list": "file:plugins\\drop-down-list",
-    "edit-view-model-base": "file:plugins\\edit-view-model-base",
-    "everlive": "file:plugins\\everlive",
-    "grid-view": "file:plugins\\grid-view",
-    "nativescript-telerik-ui": "^0.2.4",
-    "navigation": "file:plugins\\navigation",
-    "notifications": "file:plugins\\notifications",
-    "table": "file:plugins\\table",
-    "tns-core-modules": "1.7.1",
-    "validation-rules": "file:plugins\\validation-rules",
-    "view-model-base": "file:plugins\\view-model-base",
-    "sample-xpensity-app-options": "file:plugins\\app_options"
-  }
+	"nativescript": {
+		"id": "org.nativescript.Xpensity",
+		"tns-android": {
+			"version": "1.7.1"
+		},
+		"tns-ios": {
+			"version": "1.7.0"
+		}
+	},
+	"devDependencies": {
+		"nativescript-dev-typescript": "^0.3.1",
+		"typescript": "^1.8.2"
+	},
+	"dependencies": {
+		"custom-control": "file:plugins\\custom-control",
+		"data-source": "file:plugins\\data-source",
+		"date-picker": "file:plugins\\date-picker",
+		"drop-down-list": "file:plugins\\drop-down-list",
+		"edit-view-model-base": "file:plugins\\edit-view-model-base",
+		"everlive": "file:plugins\\everlive",
+		"grid-view": "file:plugins\\grid-view",
+		"nativescript-telerik-ui-pro": "^1.0.1",
+		"navigation": "file:plugins\\navigation",
+		"notifications": "file:plugins\\notifications",
+		"sample-xpensity-app-options": "file:plugins\\app_options",
+		"table": "file:plugins\\table",
+		"tns-core-modules": "1.7.1",
+		"validation-rules": "file:plugins\\validation-rules",
+		"view-model-base": "file:plugins\\view-model-base"
+	}
 }


### PR DESCRIPTION
When building the application with appbuilder cli and version 0.2.4 of nativescript-telerik-ui there is a problem with the name of the platforms/Android folder because it starts with capital letter. In the pro version 1.0.1 the name is correct and the build is successful.